### PR TITLE
Improve blog post share buttons with icons and add LinkedIn

### DIFF
--- a/src/main/resources/web/app/styles.scss
+++ b/src/main/resources/web/app/styles.scss
@@ -383,6 +383,21 @@ aside.sidebar.main {
   margin: 0;
 }
 
+/* Share buttons on blog posts */
+.page-share {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.page-share a {
+  font-size: 1.25rem;
+  transition: opacity .15s;
+}
+
+.page-share a:hover {
+  opacity: .7;
+}
+
 /* Pages conf & podcast */
 h2 {
   color: $accent;

--- a/templates/layouts/roq-default/post.html
+++ b/templates/layouts/roq-default/post.html
@@ -32,19 +32,19 @@ asciidoc-attributes:
       <div class="page-footer">
         <div class="footer-links">
           <div class="page-share">
-            <a href="https://twitter.com/intent/tweet?text={page.title}&url={page.url.encoded}"
+            <a href="https://twitter.com/intent/tweet?text={page.title}&url={page.url.absolute}"
                title="Share on Twitter" rel="nofollow" target="_blank" aria-label="Share on Twitter">
               <i class="fab fa-x-twitter" aria-hidden="true"></i>
             </a>
-            <a href="https://bsky.app/intent/compose?text={page.title}%0ACheck%20it%20out%20{page.url.encoded}"
+            <a href="https://bsky.app/intent/compose?text={page.title}%0ACheck%20it%20out%20{page.url.absolute}"
                title="Share on Bluesky" rel="nofollow" target="_blank" aria-label="Share on Bluesky">
               <i class="fab fa-bluesky" aria-hidden="true"></i>
             </a>
-            <a href="https://www.linkedin.com/sharing/share-offsite/?url={page.url.encoded}"
+            <a href="https://www.linkedin.com/sharing/share-offsite/?url={page.url.absolute}"
                title="Share on LinkedIn" rel="nofollow" target="_blank" aria-label="Share on LinkedIn">
               <i class="fab fa-linkedin" aria-hidden="true"></i>
             </a>
-            <a href="https://facebook.com/sharer.php?u={page.url.encoded}"
+            <a href="https://facebook.com/sharer.php?u={page.url.absolute}"
                title="Share on Facebook" rel="nofollow" target="_blank" aria-label="Share on Facebook">
               <i class="fab fa-facebook" aria-hidden="true"></i>
             </a>


### PR DESCRIPTION
- Replace text share links with Font Awesome icon buttons (X, Bluesky, LinkedIn, Facebook)
- Add LinkedIn as a new sharing option
- Use absolute URLs for share links to ensure correct sharing in production
- Override theme post template in templates/layouts/ for customization
- Add share button styling in styles.scss